### PR TITLE
Fix 404s identified in Google Console Search

### DIFF
--- a/categories/index.md
+++ b/categories/index.md
@@ -1,0 +1,5 @@
+---
+layout: layouts/base.njk
+eleventyExcludeFromCollections: true
+redirect: https://pentacode.app/news/
+---

--- a/categories/produktupdates.md
+++ b/categories/produktupdates.md
@@ -1,0 +1,5 @@
+---
+layout: layouts/base.njk
+eleventyExcludeFromCollections: true
+redirect: https://pentacode.app/news/
+---

--- a/hilfe/handbuch/dienstplan/plan-ist-vergleich.md
+++ b/hilfe/handbuch/dienstplan/plan-ist-vergleich.md
@@ -1,0 +1,5 @@
+---
+layout: layouts/base.njk
+eleventyExcludeFromCollections: true
+redirect: https://pentacode.app/hilfe/handbuch/dienstplan/#plan-ist-vergleich
+---

--- a/hilfe/handbuch/mitarbeiter/neuer-mitarbeiter.md
+++ b/hilfe/handbuch/mitarbeiter/neuer-mitarbeiter.md
@@ -1,0 +1,5 @@
+---
+layout: layouts/base.njk
+eleventyExcludeFromCollections: true
+redirect: https://pentacode.app/hilfe/handbuch/mitarbeiter-app/
+---


### PR DESCRIPTION
These are pages that are temporarily removed from the index which had results landing into them. I've created redirects to the new version of them.

Note this was happening before the conversion from Hugo -> 11ty.