### PR TITLE
Minor tweaks

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -104,7 +104,7 @@ module.exports = (config) => {
     config.addNunjucksShortcode("relref", (ref) => ref);
     config.addNunjucksShortcode("key", (key, extraClass = "") => html`<span class="key ${extraClass}">${key}</span>`);
     config.addNunjucksShortcode("icon", (icon) => html`<i class="fas fa-${icon}"></i>`);
-    config.addNunjucksShortcode("button", (label = "", icon = "", iconRight = "", extraClass = "") => html`<span class="fake-button ${extraClass}">${icon ? html`<i class="fas fa-${icon}"></i>` : ''} ${label ? label : ''} ${iconRight ? html`<i class="fas fa-${iconRight}"></i>` : ''}</span>`);
+    config.addNunjucksShortcode("button", ({ label = "", icon = "", iconRight = "", extraClass = "" }) => html`<span class="fake-button ${extraClass}">${icon ? html`<i class="fas fa-${icon}"></i>` : ''} ${label ? label : ''} ${iconRight ? html`<i class="fas fa-${iconRight}"></i>` : ''}</span>`);
     config.addNunjucksShortcode("param", (param) => html`<strong>[REPLACE_ME ${param}]</strong>`);
     config.addNunjucksShortcode("br", () => html`<br />`);
     config.addNunjucksShortcode(

--- a/hilfe/handbuch/einstellungen/index.md
+++ b/hilfe/handbuch/einstellungen/index.md
@@ -1,6 +1,5 @@
 ---
 layout: layouts/hilfe/index.njk
-kind: home
 title: Einstellungen
 weight: 8
 icon: cog


### PR DESCRIPTION
This effectively makes Einstellungen show the sidebar menu (which was before the Hugo -> 11ty conversion, I think), and allows the `{% button %}` shortcode to have parameters out of order, which I've noticed in a couple of places.