### PR TITLE
Fix NetlifyCMS auth failure

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -2,6 +2,7 @@ backend:
   name: github
   repo: pentacode/site
   branch: master
+  site_domain: pentacode-site.netlify.app
 
 publish_mode: editorial_workflow
 media_folder: "assets/uploads"


### PR DESCRIPTION
Hopefully this will be enough, given https://www.netlifycms.org/docs/backends-overview/ so we don't have to setup the pentacode.app domain with Netlify's DNS.