### PR TITLE
remove second mentioning of lifetime license

### DIFF
--- a/_includes/components/sections/preise.njk
+++ b/_includes/components/sections/preise.njk
@@ -17,12 +17,6 @@
                                 <div class="price-amount">3€</div>
                             </div>
                             <div class="price-unit">pro Mitarbeiter / Monat</div>
-                            <div style="font-size: 0.8em">
-                                <span style="opacity: 0.7">oder als</span>
-                                <strong class="highlight"
-                                    >Lifetime-Lizenz <sup><i class="fas fa-infinity" style="font-size: 0.8em"></i></sup
-                                ></strong>
-                            </div>
                         </div>
                         <ul class="features">
                             <li>


### PR DESCRIPTION
habe nochmal nach `license` und `lizenz` gesucht und nichts weiter gefunden