### PR TITLE
change text on primary CTA button and directly open calendar

### DIFF
--- a/_includes/layouts/home.njk
+++ b/_includes/layouts/home.njk
@@ -35,8 +35,12 @@
                 </h3>
 
                 <div class="buttons">
-                    <a href="/#contact-us" class="btn highlight get-started">
-                        <span>Jetzt Kennenlernen</span>
+                    <a 
+                        href="https://calendly.com/pentacode/demo"
+                        data-open-scheduler="true"
+                        class="btn highlight get-started"
+                    >
+                        <span>Jetzt Online Demo buchen</span>
                         <i class="icon fad fa-play-circle"></i>
                     </a>
                 </div>

--- a/_includes/layouts/home.njk
+++ b/_includes/layouts/home.njk
@@ -40,7 +40,7 @@
                         data-open-scheduler="true"
                         class="btn highlight get-started"
                     >
-                        <span>Jetzt Online Demo buchen</span>
+                        <span>Jetzt Online-Demo Buchen</span>
                         <i class="icon fad fa-play-circle"></i>
                     </a>
                 </div>


### PR DESCRIPTION
Für das direkte Verlinken auf den Kalender habe ich dieselbe Mechanik genommen, wie im Button „Online-Demo buchen“ weiter unten auf der Seite. Es öffnet sich dann in einem Dialog das Auswahlfenster für eine Produkt-Demo.

So sieht der Button jetzt aus:
![Screenshot 2024-08-16 at 11 08 22](https://github.com/user-attachments/assets/f608c0cb-4d9c-440e-8f06-fa7e12a99bb8)
