### PR TITLE
Support mp4

### DIFF
--- a/_includes/styles/hilfe.html
+++ b/_includes/styles/hilfe.html
@@ -19,6 +19,10 @@
         margin: 1em 0;
     }
 
+    article video {
+        max-width: 100%;
+    }
+
     article p,
     article h2,
     article h3,

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -104,7 +104,7 @@ export default async function (config) {
     // Old paths
     config.addPassthroughCopy({ "./assets": "/" });
 
-    config.setTemplateFormats(["html", "md", "njk", "png", "jpg", "gif", "webp"]);
+    config.setTemplateFormats(["html", "md", "njk", "png", "jpg", "gif", "webp", "mp4"]);
 
     config.addNunjucksShortcode(
         "img",


### PR DESCRIPTION
Adds support for mp4 videos on the help site to replace gifs.

Videos can be referenced using 
```
<figure>
<video src="test.mp4" autoplay muted loop playsinline></video>
<figcaption>Dies ist ein Testvideo</figcaption>
</figure>
```

<img width="1606" height="1768" alt="image" src="https://github.com/user-attachments/assets/cbb62c3c-05c2-4327-9d0c-ffe681192829" />


